### PR TITLE
Fix generic ZHA zeroconf discovery

### DIFF
--- a/esphome-config/tubeszb-cc2652p2-ethusb-2022.yaml
+++ b/esphome-config/tubeszb-cc2652p2-ethusb-2022.yaml
@@ -7,7 +7,7 @@ esphome:
     priority: 600
     then:
       - lambda: |-
-          id(mdns0).add_extra_service({ "_zigbee-gateway", "_tcp", 6638, {{"radio_type", "znp"}, {"name", "TubesZB"},{"serial_number", get_mac_address()}} });
+          id(mdns0).add_extra_service({ "_zigbee-coordinator", "_tcp", 6638, {{"radio_type", "znp"}, {"name", "TubesZB"},{"serial_number", get_mac_address()}} });
 esp32:
   board: esp-wrover-kit
   framework:

--- a/esphome-config/tubeszb-cc2652p2-ethusb-2023.yaml
+++ b/esphome-config/tubeszb-cc2652p2-ethusb-2023.yaml
@@ -7,7 +7,7 @@ esphome:
     priority: 600
     then:
       - lambda: |-
-          id(mdns0).add_extra_service({ "_zigbee-gateway", "_tcp", 6638, {{"radio_type", "znp"}, {"name", "TubesZB"},{"serial_number", get_mac_address()}} });
+          id(mdns0).add_extra_service({ "_zigbee-coordinator", "_tcp", 6638, {{"radio_type", "znp"}, {"name", "TubesZB"},{"serial_number", get_mac_address()}} });
 esp32:
   board: esp-wrover-kit
   framework:

--- a/esphome-config/tubeszb-cc2652p2-poe-2022.yaml
+++ b/esphome-config/tubeszb-cc2652p2-poe-2022.yaml
@@ -7,7 +7,7 @@ esphome:
     priority: 600
     then:
       - lambda: |-
-          id(mdns0).add_extra_service({ "_zigbee-gateway", "_tcp", 6638, {{"radio_type", "znp"}, {"name", "TubesZB"},{"serial_number", get_mac_address()}} });
+          id(mdns0).add_extra_service({ "_zigbee-coordinator", "_tcp", 6638, {{"radio_type", "znp"}, {"name", "TubesZB"},{"serial_number", get_mac_address()}} });
       - switch.turn_on: zRST_gpio
       - delay: 15ms
       - switch.turn_off: zRST_gpio

--- a/esphome-config/tubeszb-cc2652p2-poe-2023.yaml
+++ b/esphome-config/tubeszb-cc2652p2-poe-2023.yaml
@@ -7,7 +7,7 @@ esphome:
     priority: 600
     then:
       - lambda: |-
-          id(mdns0).add_extra_service({ "_zigbee-gateway", "_tcp", 6638, {{"radio_type", "znp"}, {"name", "TubesZB"},{"serial_number", get_mac_address()}} });
+          id(mdns0).add_extra_service({ "_zigbee-coordinator", "_tcp", 6638, {{"radio_type", "znp"}, {"name", "TubesZB"},{"serial_number", get_mac_address()}} });
       - switch.turn_on: zRST_gpio
       - delay: 15ms
       - switch.turn_off: zRST_gpio

--- a/esphome-config/tubeszb-cc2652p7-poe-2023.yaml
+++ b/esphome-config/tubeszb-cc2652p7-poe-2023.yaml
@@ -7,7 +7,7 @@ esphome:
     priority: 600
     then:
       - lambda: |-
-          id(mdns0).add_extra_service({ "_zigbee-gateway", "_tcp", 6638, {{"radio_type", "znp"}, {"name", "TubesZB"},{"serial_number", get_mac_address()}} });
+          id(mdns0).add_extra_service({ "_zigbee-coordinator", "_tcp", 6638, {{"radio_type", "znp"}, {"name", "TubesZB"},{"serial_number", get_mac_address()}} });
       - switch.turn_on: zRST_gpio
       - delay: 15ms
       - switch.turn_off: zRST_gpio

--- a/esphome-config/tubeszb-efr32-mgm210-poe-2023.yaml
+++ b/esphome-config/tubeszb-efr32-mgm210-poe-2023.yaml
@@ -7,7 +7,7 @@ esphome:
     priority: 600
     then:
       - lambda: |-
-          id(mdns0).add_extra_service({ "_zigbee-gateway", "_tcp", 6638, {{"radio_type", "ezsp"}, {"name", "TubesZB"},{"serial_number", get_mac_address()}} });
+          id(mdns0).add_extra_service({ "_zigbee-coordinator", "_tcp", 6638, {{"radio_type", "ezsp"}, {"name", "TubesZB"},{"serial_number", get_mac_address()}} });
 esp32:
   board: esp-wrover-kit
   framework:

--- a/esphome-config/tubeszb-efr32-mgm24-2023.yaml
+++ b/esphome-config/tubeszb-efr32-mgm24-2023.yaml
@@ -7,7 +7,7 @@ esphome:
     priority: 600
     then:
       - lambda: |-
-          id(mdns0).add_extra_service({ "_zigbee-gateway", "_tcp", 6638, {{"radio_type", "ezsp"}, {"name", "TubesZB"},{"serial_number", get_mac_address()}} });
+          id(mdns0).add_extra_service({ "_zigbee-coordinator", "_tcp", 6638, {{"radio_type", "ezsp"}, {"name", "TubesZB"},{"serial_number", get_mac_address()}} });
 
 esp32:
   board: esp-wrover-kit


### PR DESCRIPTION
The service type has changed over time. See: https://github.com/home-assistant/core/pull/126294