### PR TITLE
Revert Baudrate change

### DIFF
--- a/esphome-config/tubeszb-2026-zw-experimental.yaml
+++ b/esphome-config/tubeszb-2026-zw-experimental.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-2026-zw-experimental
   project: 
     name: tubezb.zw2026exp
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: -10

--- a/esphome-config/tubeszb-2026-zw.yaml
+++ b/esphome-config/tubeszb-2026-zw.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-2026-zw
   project: 
     name: tubezb.zw2026
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: -10

--- a/esphome-config/tubeszb-cc2652p2-ethusb-2022.yaml
+++ b/esphome-config/tubeszb-cc2652p2-ethusb-2022.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-cc2652p2-ethusb-2022
   project: 
     name: tubeszb.cc2652p2-ethusb-2022
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: 600

--- a/esphome-config/tubeszb-cc2652p2-ethusb-2023.yaml
+++ b/esphome-config/tubeszb-cc2652p2-ethusb-2023.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-cc2652p2-ethusb-2023
   project: 
     name: tubeszb.cc2652p2-ethusb-2023
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: 600

--- a/esphome-config/tubeszb-cc2652p2-poe-2022.yaml
+++ b/esphome-config/tubeszb-cc2652p2-poe-2022.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-cc2652p2-poe-2022
   project: 
     name: tubezb.cc2652p2-poe-2022
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: 600

--- a/esphome-config/tubeszb-cc2652p2-poe-2023.yaml
+++ b/esphome-config/tubeszb-cc2652p2-poe-2023.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-cc2652p2-poe-2023
   project: 
     name: tubezb.cc2652p2-poe-2023
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: 600

--- a/esphome-config/tubeszb-cc2652p7-poe-2023.yaml
+++ b/esphome-config/tubeszb-cc2652p7-poe-2023.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-cc2652p7-poe-2023
   project: 
     name: tubezb.cc2652p7-poe-2023
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: 600

--- a/esphome-config/tubeszb-dr-cc2652-exp.yaml
+++ b/esphome-config/tubeszb-dr-cc2652-exp.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-dr-cc2652-exp
   project: 
     name: tubezb.cc2652+zw
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: 600

--- a/esphome-config/tubeszb-dr-mgm21-22-exp.yaml
+++ b/esphome-config/tubeszb-dr-mgm21-22-exp.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-dr-mgm21-22-exp
   project: 
     name: tubezb.mgm21+zw
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: 600

--- a/esphome-config/tubeszb-dr-mgm24-exp.yaml
+++ b/esphome-config/tubeszb-dr-mgm24-exp.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-dr-mgm24-exp
   project: 
     name: tubezb.mgm24+zw
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: 900
@@ -219,7 +219,7 @@ select:
       - "230400"
       - "460800"
       - "921600"
-    initial_option: "460800"
+    initial_option: "115200"
     optimistic: true
     restore_value: True
     internal: false
@@ -322,7 +322,7 @@ uart:
   - id: uart_bus_zb
     rx_pin: GPIO36
     tx_pin: GPIO4
-    baud_rate: 460800
+    baud_rate: 115200
     rx_buffer_size: 8192
 
   - id: uart_bus_zw

--- a/esphome-config/tubeszb-dual-radio-kit-cc2652.yaml
+++ b/esphome-config/tubeszb-dual-radio-kit-cc2652.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-dual-radio-kit-cc2652
   project: 
     name: tubezb.cc2652+zw
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: 600

--- a/esphome-config/tubeszb-dual-radio-kit-mgm24.yaml
+++ b/esphome-config/tubeszb-dual-radio-kit-mgm24.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-dual-radio-kit-mgm24
   project: 
     name: tubezb.mgm24+zw
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: 900
@@ -295,7 +295,7 @@ select:
       - "230400"
       - "460800"
       - "921600"
-    initial_option: "460800"
+    initial_option: "115200"
     optimistic: true
     restore_value: True
     internal: false
@@ -324,7 +324,7 @@ uart:
   - id: uart_bus_zb
     rx_pin: GPIO36
     tx_pin: GPIO4
-    baud_rate: 460800
+    baud_rate: 115200
     rx_buffer_size: 8192
 
   - id: uart_bus_zw

--- a/esphome-config/tubeszb-dual-radio-mgm21-2022.yaml
+++ b/esphome-config/tubeszb-dual-radio-mgm21-2022.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-dual-radio-mgm21-2022
   project: 
     name: tubezb.mgm21+zw
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: 600

--- a/esphome-config/tubeszb-efr32-mgm210-poe-2022.yaml
+++ b/esphome-config/tubeszb-efr32-mgm210-poe-2022.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-efr32-mgm210-poe-2022
   project:
     name: tubeszb.efr32_mgm210_poe_2022
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   board: esp-wrover-kit
   framework:

--- a/esphome-config/tubeszb-efr32-mgm210-poe-2023.yaml
+++ b/esphome-config/tubeszb-efr32-mgm210-poe-2023.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-efr32-mgm210-poe-2023
   project:
     name: tubeszb.efr32_mgm210_poe_2023
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   board: esp-wrover-kit
   framework:

--- a/esphome-config/tubeszb-efr32-mgm24-2023.yaml
+++ b/esphome-config/tubeszb-efr32-mgm24-2023.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-efr32-mgm24-2023
   project:
     name: tubeszb.efr32_mgm24_2023
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: 900
@@ -219,7 +219,7 @@ select:
       - "230400"
       - "460800"
       - "921600"
-    initial_option: "460800"
+    initial_option: "115200"
     optimistic: true
     restore_value: True
     internal: false
@@ -322,7 +322,7 @@ uart:
   id: uart_bus
   rx_pin: GPIO36
   tx_pin: GPIO4
-  baud_rate: 460800
+  baud_rate: 115200
   rx_buffer_size: 8192
 
 

--- a/esphome-config/tubeszb-zw-experimental.yaml
+++ b/esphome-config/tubeszb-zw-experimental.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-zw-experimental
   project: 
     name: tubezb.zwexp
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
 
   on_boot:

--- a/esphome-config/tubeszb-zw.yaml
+++ b/esphome-config/tubeszb-zw.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-zw
   project: 
     name: tubezb.zw
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
 
   on_boot:

--- a/manifests/tubeszb-2026-zw-experimental.yaml
+++ b/manifests/tubeszb-2026-zw-experimental.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-2026-zw-experimental
   project: 
     name: tubezb.zw2026
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: -10

--- a/manifests/tubeszb-2026-zw.yaml
+++ b/manifests/tubeszb-2026-zw.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-2026-zw
   project: 
     name: tubezb.zw2026
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: -10

--- a/manifests/tubeszb-cc2652p2-ethusb-2022.yaml
+++ b/manifests/tubeszb-cc2652p2-ethusb-2022.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-cc2652p2-ethusb-2022
   project: 
     name: tubeszb.cc2652p2-ethusb-2022
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: 600

--- a/manifests/tubeszb-cc2652p2-ethusb-2023.yaml
+++ b/manifests/tubeszb-cc2652p2-ethusb-2023.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-cc2652p2-ethusb-2023
   project: 
     name: tubeszb.cc2652p2-ethusb-2023
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: 600

--- a/manifests/tubeszb-cc2652p2-poe-2022.yaml
+++ b/manifests/tubeszb-cc2652p2-poe-2022.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-cc2652p2-poe-2022
   project: 
     name: tubezb.cc2652p2-poe-2022
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: 600

--- a/manifests/tubeszb-cc2652p2-poe-2023.yaml
+++ b/manifests/tubeszb-cc2652p2-poe-2023.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-cc2652p2-poe-2023
   project: 
     name: tubezb.cc2652p2-poe-2023
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: 600

--- a/manifests/tubeszb-cc2652p7-poe-2023.yaml
+++ b/manifests/tubeszb-cc2652p7-poe-2023.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-cc2652p7-poe-2023
   project: 
     name: tubezb.cc2652p7-poe-2023
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: 600

--- a/manifests/tubeszb-dr-cc2652-exp.yaml
+++ b/manifests/tubeszb-dr-cc2652-exp.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-dr-cc2652-exp
   project: 
     name: tubezb.cc2652+zw
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: 600

--- a/manifests/tubeszb-dr-mgm21-22-exp.yaml
+++ b/manifests/tubeszb-dr-mgm21-22-exp.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-dr-mgm21-22-exp
   project: 
     name: tubezb.mgm21+zw
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: 600

--- a/manifests/tubeszb-dr-mgm24-exp.yaml
+++ b/manifests/tubeszb-dr-mgm24-exp.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-dr-mgm24-exp
   project: 
     name: tubezb.mgm24+zw
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: 900
@@ -309,7 +309,7 @@ select:
       - "230400"
       - "460800"
       - "921600"
-    initial_option: "460800"
+    initial_option: "115200"
     optimistic: true
     restore_value: True
     internal: false
@@ -338,7 +338,7 @@ uart:
   - id: uart_bus_zb
     rx_pin: GPIO36
     tx_pin: GPIO4
-    baud_rate: 460800
+    baud_rate: 115200
     rx_buffer_size: 8192
 
   - id: uart_bus_zw

--- a/manifests/tubeszb-dual-radio-kit-cc2652.yaml
+++ b/manifests/tubeszb-dual-radio-kit-cc2652.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-dual-radio-kit-cc2652
   project: 
     name: tubezb.cc2652+zw
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: 600

--- a/manifests/tubeszb-dual-radio-kit-mgm24.yaml
+++ b/manifests/tubeszb-dual-radio-kit-mgm24.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-dual-radio-kit-mgm24
   project: 
     name: tubezb.mgm24+zw
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: 900
@@ -291,7 +291,7 @@ select:
       - "230400"
       - "460800"
       - "921600"
-    initial_option: "460800"
+    initial_option: "115200"
     optimistic: true
     restore_value: True
     internal: false
@@ -320,7 +320,7 @@ uart:
   - id: uart_bus_zb
     rx_pin: GPIO36
     tx_pin: GPIO4
-    baud_rate: 460800
+    baud_rate: 115200
     rx_buffer_size: 8192
 
   - id: uart_bus_zw

--- a/manifests/tubeszb-dual-radio-mgm21-2022.yaml
+++ b/manifests/tubeszb-dual-radio-mgm21-2022.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-dual-radio-mgm21-2022
   project: 
     name: tubezb.mgm21+zw
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: 600

--- a/manifests/tubeszb-efr32-mgm210-poe-2022.yaml
+++ b/manifests/tubeszb-efr32-mgm210-poe-2022.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-efr32-mgm210-poe-2022
   project:
     name: tubeszb.efr32_mgm210_poe_2022
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: 150   # restore user-selected baud after core init/reset sequence

--- a/manifests/tubeszb-efr32-mgm210-poe-2023.yaml
+++ b/manifests/tubeszb-efr32-mgm210-poe-2023.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-efr32-mgm210-poe-2023
   project:
     name: tubeszb.efr32_mgm210_poe_2023
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: 150   # restore user-selected baud after core init/reset sequence

--- a/manifests/tubeszb-efr32-mgm24-2023.yaml
+++ b/manifests/tubeszb-efr32-mgm24-2023.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-efr32-mgm24-2023
   project:
     name: tubeszb.efr32_mgm24_2023
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
   on_boot:
     - priority: 900
@@ -307,7 +307,7 @@ select:
       - "230400"
       - "460800"
       - "921600"
-    initial_option: "460800"
+    initial_option: "115200"
     optimistic: true
     restore_value: True
     internal: false
@@ -336,7 +336,7 @@ uart:
   id: uart_bus
   rx_pin: GPIO36
   tx_pin: GPIO4
-  baud_rate: 460800
+  baud_rate: 115200
   rx_buffer_size: 8192
 
 

--- a/manifests/tubeszb-zw-experimental.yaml
+++ b/manifests/tubeszb-zw-experimental.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-zw-experimental
   project: 
     name: tubezb.zwexp
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
 
   on_boot:

--- a/manifests/tubeszb-zw.yaml
+++ b/manifests/tubeszb-zw.yaml
@@ -2,7 +2,7 @@ esphome:
   name: tubeszb-zw
   project: 
     name: tubezb.zw
-    version: "2026.03.28"
+    version: "2026.03.28.1"
   min_version: 2026.3.2
 
   on_boot:


### PR DESCRIPTION
reverts baudrate for mg24 radios back to 115200 from 460800 (used in newer firmwares)